### PR TITLE
Use replaceAll when replacing separators

### DIFF
--- a/addon/services/barcode-parser.js
+++ b/addon/services/barcode-parser.js
@@ -19,7 +19,7 @@ export default class BarcodeParserService extends Service {
 
   replaceSeparators(barcode) {
     this.groupSeparators.forEach((sep) => {
-      barcode = barcode.replace(sep, FNC1);
+      barcode = barcode.replaceAll(sep, FNC1);
     });
     return barcode;
   }


### PR DESCRIPTION
Since it's possible for a barcode to contain multiple instances of a given separator, BarcodeParserService.replaceSeparators should use replaceAll(...) instead of replace(...).